### PR TITLE
Fix: Resolver errores de compilación en frontend

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,19 @@
+/* Estilos globales o overrides para Bootstrap pueden ir aquí */
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+
+/* Para asegurar que el ToastContainer esté sobre otros elementos si se usa z-index en otros sitios */
+.toast-container {
+  z-index: 1060 !important; /* Bootstrap usa z-index hasta 1055 para modales */
+}

--- a/frontend/src/pages/TurnosPage.js
+++ b/frontend/src/pages/TurnosPage.js
@@ -5,7 +5,7 @@ import TurnoList from '../components/turnos/TurnoList';
 import TurnoForm from '../components/turnos/TurnoForm';
 import ConfirmModal from '../components/ConfirmModal';
 import { fetchTurnos, deleteTurno as apiDeleteTurno } from '../api';
-import { PlusCircleFill, FunnelFill } from 'react-bootstrap-icons';
+import { PlusCircleFill } from 'react-bootstrap-icons'; // Eliminado FunnelFill
 
 const TurnosPage = () => {
     const [turnos, setTurnos] = useState([]);

--- a/frontend/src/reportWebVitals.js
+++ b/frontend/src/reportWebVitals.js
@@ -1,0 +1,13 @@
+const reportWebVitals = onPerfEntry => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals;


### PR DESCRIPTION
- Añadir archivos faltantes: index.css y reportWebVitals.js a frontend/src.
- Eliminar importación no utilizada (FunnelFill) en TurnosPage.js.

Estos cambios resuelven los errores 'Module not found' y advertencias que impedían la compilación exitosa del proyecto frontend.